### PR TITLE
Fixed failing tests due to change in schema metabrainz/mmd-schema@25b453f

### DIFF
--- a/servlet/src/test/java/org/musicbrainz/search/servlet/FindAnnotationTest.java
+++ b/servlet/src/test/java/org/musicbrainz/search/servlet/FindAnnotationTest.java
@@ -320,7 +320,7 @@ public class FindAnnotationTest {
 
     assertTrue(output.contains("\"count\":1"));
     assertTrue(output.contains("\"offset\":0,"));
-    assertTrue(output.contains("\"score\":\"100\","));
+    assertTrue(output.contains("\"score\":100,"));
     assertTrue(output.contains("\"name\":\"Pieds nus sur la braise\""));
     assertTrue(output.contains("\"type\":\"release\""));
     assertTrue(output.contains("\"entity\":\"bdb24cb5-404b-4f60-bba4-7b730325ae47\""));
@@ -342,7 +342,7 @@ public class FindAnnotationTest {
     System.out.println("Json New is" + output);
 
     assertTrue(output.contains("annotations"));
-    assertTrue(output.contains("\"score\":\"100\","));
+    assertTrue(output.contains("\"score\":100,"));
     assertTrue(output.contains("\"name\":\"Pieds nus sur la braise\""));
     assertTrue(output.contains("\"type\":\"release\""));
     assertTrue(output.contains("\"entity\":\"bdb24cb5-404b-4f60-bba4-7b730325ae47\""));

--- a/servlet/src/test/java/org/musicbrainz/search/servlet/FindArtistTest.java
+++ b/servlet/src/test/java/org/musicbrainz/search/servlet/FindArtistTest.java
@@ -625,8 +625,8 @@ public class FindArtistTest {
         writer.write(pr, res, SearchServerServlet.RESPONSE_JSON);
         pr.close();
         String output = sw.toString();
-        assertTrue(output.contains("\"score\":\"100\""));
-        assertTrue(output.contains("\"score\":\"31\""));
+        assertTrue(output.contains("\"score\":100"));
+        assertTrue(output.contains("\"score\":31"));
     }
 
     /**

--- a/servlet/src/test/java/org/musicbrainz/search/servlet/FindCDStubTest.java
+++ b/servlet/src/test/java/org/musicbrainz/search/servlet/FindCDStubTest.java
@@ -201,7 +201,7 @@ public class FindCDStubTest {
 
     assertTrue(output.contains("\"count\":1"));
     assertTrue(output.contains("\"offset\":0,"));
-    assertTrue(output.contains("\"score\":\"100\","));
+    assertTrue(output.contains("\"score\":100,"));
     assertTrue(output.contains("\"id\":\"qA87dKURKperVfmckD5b_xo8BO8-\""));
     assertTrue(output.contains("\"title\":\"Doo Doo First\""));
     assertTrue(output.contains("\"artist\":\"Doo Doo\""));
@@ -227,7 +227,7 @@ public class FindCDStubTest {
     assertTrue(output.contains("cdstubs"));
     assertTrue(output.contains("\"count\":1"));
     assertTrue(output.contains("\"offset\":0,"));
-    assertTrue(output.contains("\"score\":\"100\","));
+    assertTrue(output.contains("\"score\":100,"));
     assertTrue(output.contains("\"id\":\"qA87dKURKperVfmckD5b_xo8BO8-\""));
     assertTrue(output.contains("\"count\":2"));
     assertTrue(output.contains("\"title\":\"Doo Doo First\""));

--- a/servlet/src/test/java/org/musicbrainz/search/servlet/FindFreeDBTest.java
+++ b/servlet/src/test/java/org/musicbrainz/search/servlet/FindFreeDBTest.java
@@ -181,7 +181,7 @@ public class FindFreeDBTest  {
 
     assertTrue(output.contains("\"count\":1"));
     assertTrue(output.contains("\"offset\":0,"));
-    assertTrue(output.contains("\"score\":\"100\","));
+    assertTrue(output.contains("\"score\":100,"));
     assertTrue(output.contains("\"id\":\"c20c4b0d\""));
     assertTrue(output.contains("\"title\":\"L\u00e1grimas & Gozos\""));
     assertTrue(output.contains("\"artist\":\"Ska-P\""));
@@ -205,7 +205,7 @@ public class FindFreeDBTest  {
     System.out.println("Json New is" + output);
 
     assertTrue(output.contains("freedb-discs"));
-    assertTrue(output.contains("\"score\":\"100\","));
+    assertTrue(output.contains("\"score\":100,"));
     assertTrue(output.contains("\"id\":\"c20c4b0d\""));
     assertTrue(output.contains("\"title\":\"L\u00e1grimas & Gozos\""));
     assertTrue(output.contains("\"artist\":\"Ska-P\""));

--- a/servlet/src/test/java/org/musicbrainz/search/servlet/FindRecordingTest.java
+++ b/servlet/src/test/java/org/musicbrainz/search/servlet/FindRecordingTest.java
@@ -574,7 +574,7 @@ public class FindRecordingTest {
         assertTrue(output.contains("id\":\"7ca7782b-a602-448b-b108-bb881a7be2d6\""));
         assertTrue(output.contains("\"count\":1"));
         assertTrue(output.contains("\"offset\":0,"));
-        assertTrue(output.contains("\"score\":\"100\""));
+        assertTrue(output.contains("\"score\":100"));
         assertTrue(output.contains("\"type\":\"Compilation\""));
         assertTrue(output.contains("title\":\"Gravitational Lenz\""));
         assertTrue(output.contains("\"length\":234000"));
@@ -611,7 +611,7 @@ public class FindRecordingTest {
 
         assertTrue(output.contains("recordings"));
         assertTrue(output.contains("id\":\"7ca7782b-a602-448b-b108-bb881a7be2d6\""));
-        assertTrue(output.contains("\"score\":\"100\""));
+        assertTrue(output.contains("\"score\":100"));
         assertTrue(output.contains("title\":\"Gravitational Lenz\""));
         assertTrue(output.contains("\"isrcs\":[{\"id\":\"123456789"));
         assertTrue(output.contains("\"status\":\"Official\""));

--- a/servlet/src/test/java/org/musicbrainz/search/servlet/FindReleaseGroupTest.java
+++ b/servlet/src/test/java/org/musicbrainz/search/servlet/FindReleaseGroupTest.java
@@ -524,8 +524,8 @@ public class FindReleaseGroupTest {
     String output = sw.toString();
     System.out.println("Json is" + output);
 
-    assertTrue(output.contains("\"score\":\"100\""));
-    assertTrue(output.contains("\"score\":\"43\""));
+    assertTrue(output.contains("\"score\":100"));
+    assertTrue(output.contains("\"score\":43"));
     assertTrue(output.contains("\"tag\":[{\"count\":101,\"name\":\"indie\"}"));
   }
 

--- a/servlet/src/test/java/org/musicbrainz/search/servlet/FindWorkTest.java
+++ b/servlet/src/test/java/org/musicbrainz/search/servlet/FindWorkTest.java
@@ -483,7 +483,7 @@ public class FindWorkTest {
         assertTrue(output.contains("\"offset\":0"));
         assertTrue(output.contains("\"work\":[{\"id\":\"4ff89cf0-86af-11de-90ed-001fc6f176ff\""));
         assertTrue(output.contains("\"type\":\"Opera\""));
-        assertTrue(output.contains("\"score\":\"100\""));
+        assertTrue(output.contains("\"score\":100"));
         assertTrue(output.contains("\"title\":\"Symphony No. 5\""));
         assertTrue(output.contains("\"language\":\"mul\""));
         assertTrue(output.contains("\"iswc-list\":{\"iswc\":[\"T-101779304-1\",\"B-101779304-1\"]}"));
@@ -522,7 +522,7 @@ public class FindWorkTest {
         assertTrue(output.contains("\"offset\":0"));
         assertTrue(output.contains("\"works\":[{\"id\":\"4ff89cf0-86af-11de-90ed-001fc6f176ff\""));
         assertTrue(output.contains("\"type\":\"Opera\""));
-        assertTrue(output.contains("\"score\":\"100\""));
+        assertTrue(output.contains("\"score\":100"));
         assertTrue(output.contains("\"title\":\"Symphony No. 5\""));
         assertTrue(output.contains("\"language\":\"mul\""));
         assertTrue(output.contains("languages\":[\"eng\",\"fra\"]"));


### PR DESCRIPTION
Removed quoting around test score values as the generated JSON now renders integers for scores as opposed to strings.