### PR TITLE
Fixed: String cannot be converted to Packaging

### DIFF
--- a/index/src/main/java/org/musicbrainz/search/index/ReleaseIndex.java
+++ b/index/src/main/java/org/musicbrainz/search/index/ReleaseIndex.java
@@ -483,7 +483,9 @@ public class  ReleaseIndex extends DatabaseIndex {
         String packaging = rs.getString("packaging");
         doc.addFieldOrUnknown(ReleaseIndexField.PACKAGING, packaging);
         if (!Strings.isNullOrEmpty(packaging)) {
-            release.setPackaging(packaging);
+	    Packaging pkg = new Packaging();
+	    pkg.setContent(packaging);
+            release.setPackaging(pkg);
         }
 
         String comment = rs.getString("comment");


### PR DESCRIPTION
Fixed and error which caused compilation failure due to a type mismatch.
ReleaseIndex.java:[486,33] error: incompatible types: String cannot be converted to Packaging
The expected argument to release.setPackaging() method is an instance of Packaging, but a string was being passed.